### PR TITLE
TGAColor: Conformance to 'ExpressibleByArrayLiteral'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ var image = TGAImage(width: 4, height: 1, color: .white)
 image[0, 0] = .red
 image[1, 0] = .green
 image[2, 0] = .blue
-image[3, 0] = TGAColor(r: 255, g: 165, b: 0)
+image[3, 0] = [255, 165, 0]
 
 // 💾 Writing the '.tga' data to disk
 let data = image.tgaData()

--- a/Sources/TGAImage/TGAColor.swift
+++ b/Sources/TGAImage/TGAColor.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// The order in which the RGB properties of this object are stored matters. They are stored in `(b,g,r)` which enables
 /// us to use their `Data` representation to store the values directly in the `TGAImage` without rearranging the bytes.
-public struct TGAColor: Equatable {
+public struct TGAColor : Equatable {
 
     /// The color depth of each RGB component of the color.
     public typealias ColorDepth = UInt8
@@ -50,5 +50,24 @@ public extension TGAColor {
 
     /// A color object with RGB values of 0, 0, and 255, representing the "Blue" color (Hex: `#0000ff`).
     static let blue = Self(r: 0, g: 0, b: 255)
+
+}
+
+// MARK: - ExpressibleByArrayLiteral
+
+extension TGAColor : ExpressibleByArrayLiteral {
+
+    public typealias ArrayLiteralElement = ColorDepth
+
+    /// Creates a color from the specified elements.
+    ///
+    /// - Precondition: `elements` need to have three elements.
+    ///
+    /// - Parameters:
+    ///     - elements: The elements to construct the color.
+    public init(arrayLiteral elements: ArrayLiteralElement...) {
+        guard elements.count == 3 else { preconditionFailure("Three elements expected, got \(elements.count).") }
+        self.init(r: elements[0], g: elements[1], b: elements[2])
+    }
 
 }

--- a/Tests/TGAImageTests/TGAColorTests.swift
+++ b/Tests/TGAImageTests/TGAColorTests.swift
@@ -12,6 +12,15 @@ final class TGAColorTests: XCTestCase {
         XCTAssertEqual(3, color.b)
     }
 
+    // MARK: ExpressibleByArrayLiteral Tests
+
+    func testTheExpressibleByArrayLiteralInitializer() {
+        let color: TGAColor = [1, 2, 3]
+        XCTAssertEqual(1, color.r)
+        XCTAssertEqual(2, color.g)
+        XCTAssertEqual(3, color.b)
+    }
+
     // MARK: Data Tests
 
     func testTheFirstByteContainsBlue() {


### PR DESCRIPTION
With this conformance we can specify 'TGAColor'
object as an array of UInt8 values.

E.g.

```
let color: TGAColor = [255, 0, 0] // red
```

This style is cribbed from the 'SIMD' vector type of
the Swift Standard Library.